### PR TITLE
Proxmox: Add helper script to install Yocto KVM machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# infra
+# Unbrikd Infrastructure
+
+This repository contains the source code used to setup and maintain the Unbrikd infrastructure. Its contents are organized by technology aiming to provide a single source reference for the Unbrikd infrastructure.

--- a/proxmox/helpers/yocto-kvm/README.md
+++ b/proxmox/helpers/yocto-kvm/README.md
@@ -5,5 +5,5 @@ This script is used to setup a KVM for Yocto based Linux distribution.
 ## Installation
 
 ```bash
-bash -c "$(wget -qLO - https://github.com/unbrikd/infra/raw/master/proxmox/helpers/yocto-kvm/setup.sh)"
+bash -c "$(wget -qLO - https://raw.githubusercontent.com/unbrikd/infra/refs/heads/master/proxmox/helpers/yocto-kvm/setup.sh)"
 ```

--- a/proxmox/helpers/yocto-kvm/setup.sh
+++ b/proxmox/helpers/yocto-kvm/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-#source <(curl -s https://raw.githubusercontent.com/unbrikd/infra/master/proxmox/misc/common.sh)
+source <(curl -s https://raw.githubusercontent.com/unbrikd/infra/refs/heads/feature/add-pve-helper-for-yocto-kvm/proxmox/misc/common.sh)
 
 # KVM Setup Details
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')

--- a/proxmox/helpers/yocto-kvm/setup.sh
+++ b/proxmox/helpers/yocto-kvm/setup.sh
@@ -8,13 +8,7 @@ NEXTID=$(pvesh get /cluster/nextid)
 WHIPTAIL_BACKTITLE="${FOOTER}"
 WHIPTAIL_TITLE="Yocto Linux KVM"
 
-# KVM Default Settings
-
-
-# Set the trap handlers
-# When an ERR signal is received, call the error_handler function
 trap 'error_handler $LINENO "$BASH_COMMAND"' ERR
-# When the script exits unexpectedly or (Ctrl+C), call the cleanup function
 trap cleanup EXIT
 
 # Set default settings for the machine to be created and print them to the console
@@ -230,7 +224,6 @@ function advanced_settings() {
 }
 
 function start_script() {
-  year=$(date +%Y)
   if (whiptail --backtitle "${WHIPTAIL_BACKTITLE}" --title "SETTINGS" --yesno "Use Default Settings?" --no-button Advanced 10 58); then
     header_info
     echo -e "${BL}Using Default Settings${CL}"
@@ -250,7 +243,7 @@ function set_download_url() {
         # check if the URL is valid
         if curl -s -I $URL | grep -q "200 OK"; then
           # print url first 30 characters
-          echo -e "${DGN}Using Download URL: ${BGN}${URL:0:30}${CL}"
+          echo -e "${DGN}Using Download URL: ${BGN}${URL:0:30}***${CL}"
           break
         else
           echo -e "${CROSS}${RD} Invalid URL${CL}"
@@ -285,21 +278,21 @@ pve_check
 ssh_check
 start_script
 
-msg_info "Setting Hostname"
+msg_info "Setting VM Name"
 get_vm_hn
 
 msg_info "Validating Storage"
 validate_storage
 
 msg_ok "Using ${CL}${BL}$STORAGE${CL} ${GN}for Storage Location."
-
 msg_ok "Virtual Machine ID is ${CL}${BL}$VMID${CL}."
+
 msg_info "Retrieving the URL for the Yocto Linux .qcow2 Disk Image\n"
 set_download_url
 
 FILE="${HN}.qcow2"
 sleep 2
-msg_ok "${CL}${BL}${URL}${CL}"
+msg_ok "${CL}${BL}${URL:0:30}***${CL}"
 wget -q --show-progress $URL -O $FILE
 echo -en "\e[1A\e[0K"
 

--- a/proxmox/helpers/yocto-kvm/setup.sh
+++ b/proxmox/helpers/yocto-kvm/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-source <(curl -s https://raw.githubusercontent.com/unbrikd/infra/master/proxmox/misc/common.sh)
+#source <(curl -s https://raw.githubusercontent.com/unbrikd/infra/master/proxmox/misc/common.sh)
 
 # KVM Setup Details
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')

--- a/proxmox/helpers/yocto-kvm/setup.sh
+++ b/proxmox/helpers/yocto-kvm/setup.sh
@@ -249,7 +249,8 @@ function set_download_url() {
       if [ -n "$URL" ]; then
         # check if the URL is valid
         if curl -s -I $URL | grep -q "200 OK"; then
-          echo -e "${DGN}Using Download URL: ${BGN}$URL${CL}"
+          # print url first 30 characters
+          echo -e "${DGN}Using Download URL: ${BGN}${URL:0:30}${CL}"
           break
         else
           echo -e "${CROSS}${RD} Invalid URL${CL}"
@@ -283,6 +284,9 @@ arch_check
 pve_check
 ssh_check
 start_script
+
+msg_info "Setting Hostname"
+get_vm_hn
 
 msg_info "Validating Storage"
 validate_storage

--- a/proxmox/misc/common.sh
+++ b/proxmox/misc/common.sh
@@ -1,5 +1,48 @@
+# Common informations to standardize the output of the scripts
 YEAR=$(date +%Y)
 FOOTER="Unbrikd, ${YEAR} (c)"
+
+# Colors
+YW=$(echo "\033[33m")
+YWB=$(echo "\033[93m")
+BL=$(echo "\033[36m")
+RD=$(echo "\033[01;31m")
+BGN=$(echo "\033[4;92m")
+GN=$(echo "\033[1;92m")
+DGN=$(echo "\033[32m")
+
+# Formatting
+CL=$(echo "\033[m")
+UL=$(echo "\033[4m")
+BOLD=$(echo "\033[1m")
+BFR="\\r\\033[K"
+HOLD=" "
+TAB="  "
+
+# Icons
+CM="${TAB}✔️${TAB}${CL}"
+CROSS="${TAB}✖️${TAB}${CL}"
+INFO="${TAB}💡${TAB}${CL}"
+OS="${TAB}🖥️${TAB}${CL}"
+OSVERSION="${TAB}🌟${TAB}${CL}"
+CONTAINERTYPE="${TAB}📦${TAB}${CL}"
+DISKSIZE="${TAB}💾${TAB}${CL}"
+CPUCORE="${TAB}🧠${TAB}${CL}"
+RAMSIZE="${TAB}🛠️${TAB}${CL}"
+SEARCH="${TAB}🔍${TAB}${CL}"
+VERIFYPW="${TAB}🔐${TAB}${CL}"
+CONTAINERID="${TAB}🆔${TAB}${CL}"
+HOSTNAME="${TAB}🏠${TAB}${CL}"
+BRIDGE="${TAB}🌉${TAB}${CL}"
+NETWORK="${TAB}📡${TAB}${CL}"
+GATEWAY="${TAB}🌐${TAB}${CL}"
+DISABLEIPV6="${TAB}🚫${TAB}${CL}"
+DEFAULT="${TAB}⚙️${TAB}${CL}"
+MACADDRESS="${TAB}🔗${TAB}${CL}"
+VLANTAG="${TAB}🏷️${TAB}${CL}"
+ROOTSSH="${TAB}🔑${TAB}${CL}"
+CREATING="${TAB}🚀${TAB}${CL}"
+ADVANCED="${TAB}🧩${TAB}${CL}"
 
 function header_info {
   clear

--- a/proxmox/misc/common.sh
+++ b/proxmox/misc/common.sh
@@ -67,51 +67,6 @@ function header_info {
 EOF
 }
 
-# This function sets various color variables using ANSI escape codes for formatting text in the terminal.
-color() {
-  # Colors
-  YW=$(echo "\033[33m")
-  YWB=$(echo "\033[93m")
-  BL=$(echo "\033[36m")
-  RD=$(echo "\033[01;31m")
-  BGN=$(echo "\033[4;92m")
-  GN=$(echo "\033[1;92m")
-  DGN=$(echo "\033[32m")
-
-  # Formatting
-  CL=$(echo "\033[m")
-  UL=$(echo "\033[4m")
-  BOLD=$(echo "\033[1m")
-  BFR="\\r\\033[K"
-  HOLD=" "
-  TAB="  "
-
-  # Icons
-  CM="${TAB}✔️${TAB}${CL}"
-  CROSS="${TAB}✖️${TAB}${CL}"
-  INFO="${TAB}💡${TAB}${CL}"
-  OS="${TAB}🖥️${TAB}${CL}"
-  OSVERSION="${TAB}🌟${TAB}${CL}"
-  CONTAINERTYPE="${TAB}📦${TAB}${CL}"
-  DISKSIZE="${TAB}💾${TAB}${CL}"
-  CPUCORE="${TAB}🧠${TAB}${CL}"
-  RAMSIZE="${TAB}🛠️${TAB}${CL}"
-  SEARCH="${TAB}🔍${TAB}${CL}"
-  VERIFYPW="${TAB}🔐${TAB}${CL}"
-  CONTAINERID="${TAB}🆔${TAB}${CL}"
-  HOSTNAME="${TAB}🏠${TAB}${CL}"
-  BRIDGE="${TAB}🌉${TAB}${CL}"
-  NETWORK="${TAB}📡${TAB}${CL}"
-  GATEWAY="${TAB}🌐${TAB}${CL}"
-  DISABLEIPV6="${TAB}🚫${TAB}${CL}"
-  DEFAULT="${TAB}⚙️${TAB}${CL}"
-  MACADDRESS="${TAB}🔗${TAB}${CL}"
-  VLANTAG="${TAB}🏷️${TAB}${CL}"
-  ROOTSSH="${TAB}🔑${TAB}${CL}"
-  CREATING="${TAB}🚀${TAB}${CL}"
-  ADVANCED="${TAB}🧩${TAB}${CL}"
-}
-
 function error_handler() {
   local exit_code="$?"
   local line_number="$1"


### PR DESCRIPTION
Helper script tailored to install Yocto KVM images using a download URL for the respective `.qcow2` file. Such helper script defaults to the most common configuration of embedded linux devices: 4GB RAM and 32GB of disk.